### PR TITLE
Document User-Agent requirement and add warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,21 @@ Web app that can find the app behind a given Google Client ID (such as 12345.app
 
 ## How it works
 
-The Google OAuth error pages provide hidden data about the app when provided a client ID for debugging purposes. This app fetches those pages, scrapes the data and displays the app information in a nice way.
+The Google OAuth error pages previously provided hidden data about the app when provided a client ID for debugging purposes. This app attempts to fetch those pages, scrape the data and display the app information in a nice way.
 
-This might be broken by changes Google makes to their OAuth sign-in pages.
+**⚠️ Current Status:** As of 2025, Google requires a proper browser `User-Agent` header to return OAuth pages with embedded app data. Without this header, Google returns a JavaScript-rendered page where the `data-client-auth-config-brand` attribute contains template code (e.g., `'+_.G(_.qg(e))+'`) instead of actual data.
+
+**This tool no longer works** because:
+- It runs entirely in the browser (client-side)
+- Browsers cannot send custom headers to Google due to CORS restrictions
+- CORS proxies (like corsproxy.io) strip the `User-Agent` header
+
+**To fix this tool**, it would need to be converted to use a backend server that can:
+- Send requests to Google with a proper browser `User-Agent` header
+- Bypass CORS restrictions
+- Alternatively, use a headless browser solution (Puppeteer/Playwright)
+
+This tool is subject to breaking changes whenever Google updates their OAuth sign-in pages.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Google now requires a proper browser User-Agent header to return OAuth pages with embedded app data. Without this header, the response contains JavaScript template code instead of actual data.

Since this tool runs client-side and uses CORS proxies (which strip the User-Agent header), it no longer works.

## Changes

- Updated README to explain the User-Agent requirement and why the tool is broken
- Added warning banner to the UI with workaround instructions  
- Cleaned up error handling in the scraping logic