### PR TITLE
Add manual lookup fallbacks and bundled proxy worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,11 @@ Web app that can find the app behind a given Google Client ID (such as 12345.app
 
 ## How it works
 
-The Google OAuth error pages previously provided hidden data about the app when provided a client ID for debugging purposes. This app attempts to fetch those pages, scrape the data and display the app information in a nice way.
+Google's OAuth error page (`https://accounts.google.com/signin/oauth/error?client_id=...&flowName=GeneralOAuthFlow`) embeds details about the app — name, logo, support email, terms of service and privacy policy URLs — in `AF_initDataCallback` script chunks. This app fetches that page, scrapes the data and displays it in a nice way.
 
-**⚠️ Current Status:** As of 2025, Google requires a proper browser `User-Agent` header to return OAuth pages with embedded app data. Without this header, Google returns a JavaScript-rendered page where the `data-client-auth-config-brand` attribute contains template code (e.g., `'+_.G(_.qg(e))+'`) instead of actual data.
+**⚠️ Current status:** in-browser lookup is unreliable. Google only serves the page with app details to requests with a browser-like `User-Agent`, and rejects (403) requests carrying `Sec-Fetch-Site: cross-site` — a header browsers force-attach to cross-site fetches and JavaScript cannot remove. Public pass-through CORS proxies forward that header, so they all fail. The site falls back to showing a curl command whose output can be pasted back in (or piped through jq) to get the same details.
 
-**This tool no longer works** because:
-- It runs entirely in the browser (client-side)
-- Browsers cannot send custom headers to Google due to CORS restrictions
-- CORS proxies (like corsproxy.io) strip the `User-Agent` header
-
-**To fix this tool**, it would need to be converted to use a backend server that can:
-- Send requests to Google with a proper browser `User-Agent` header
-- Bypass CORS restrictions
-- Alternatively, use a headless browser solution (Puppeteer/Playwright)
+**To fix properly**, deploy the bundled proxy worker (see [worker/README.md](worker/README.md)), which makes its own clean request to Google, and add its URL to `corsProxies` in `src/pages/index.tsx`.
 
 This tool is subject to breaking changes whenever Google updates their OAuth sign-in pages.
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -132,8 +132,39 @@ const Home = () => {
 		}
 	};
 
-	const curlCommand = (clientId: string) => `curl -s -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36" \\
-  "${googleErrorPageUrl(clientId || 'YOUR_CLIENT_ID')}" \\
+	const [pastedHtml, setPastedHtml] = useState('');
+
+	const onParsePastedHtml = (clientId: string) => {
+		const chunks = extractDataChunks(pastedHtml);
+		const brand = findBrandChunk(chunks);
+		if (!brand) {
+			setAppDetails({
+				type: 'error',
+				error: new Error('Could not find app details in the pasted output. Check the command ran successfully and you pasted its full output — and double-check the client ID is correct.'),
+				id: clientId,
+			});
+			return;
+		}
+
+		setPastedHtml('');
+		setAppDetails({
+			type: 'loaded',
+			appDetails: {
+				id: clientId,
+				name: brand[0],
+				termsUrls: brand[1],
+				privacyUrls: brand[2],
+				email: typeof brand[3] === 'string' ? brand[3] : undefined,
+				logoSrc: findLogoSrc(chunks),
+			},
+		});
+	};
+
+	const browserUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+	const curlCommand = (clientId: string) => `curl -s -A "${browserUserAgent}" "${googleErrorPageUrl(clientId || 'YOUR_CLIENT_ID')}"`;
+
+	const curlJqCommand = (clientId: string) => `${curlCommand(clientId)} \\
   | grep -o "AF_initDataCallback({key: 'ds:1', hash: '[0-9]*', data:\\[[^;]*\\], sideChannel" \\
   | sed "s/.*data://; s/, sideChannel//" \\
   | jq '{name: .[0], termsOfService: .[1], privacyPolicy: .[2], email: .[3]}'`;
@@ -148,6 +179,12 @@ const Home = () => {
 				This tool can find the app details behind a given Google Client ID (such as
 				12345.apps.googleusercontent.com).
 			</p>
+
+			<div className='mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg text-yellow-800 text-sm'>
+				⚠️ In-browser lookup is currently unreliable: Google blocks requests made via public CORS
+				proxies, which this page depends on. If the lookup fails, the error screen includes a
+				manual lookup that takes about 30 seconds.
+			</div>
 
 			{appDetails.type === 'ready' && (
 				<div className='mb-6'>
@@ -191,9 +228,33 @@ const Home = () => {
 					<div className='mt-4'>
 						<div className='text-red-700 font-medium mb-1'>Manual lookup</div>
 						<p className='text-red-600 text-sm mb-2'>
-							You can get the same details yourself with curl and <a href='https://jqlang.org/' target='_blank' rel='noopener noreferrer' className='underline'>jq</a>:
+							Run this in a terminal (Google will only answer requests that look like they come from a browser):
 						</p>
 						<pre className='bg-red-100 text-red-900 text-xs p-3 rounded overflow-x-auto whitespace-pre-wrap break-all'><code>{curlCommand(appDetails.id)}</code></pre>
+						<p className='text-red-600 text-sm my-2'>
+							Then paste the output here and the app details will be extracted from it:
+						</p>
+						<textarea
+							value={pastedHtml}
+							onChange={(e) => {
+								setPastedHtml(e.target.value);
+							}}
+							placeholder='Paste the command output here...'
+							className='w-full h-24 px-3 py-2 text-xs border border-red-300 rounded-md outline-none focus:ring-2 ring-red-200 transition-all font-mono'
+						/>
+						<button
+							type='button'
+							className='mt-1 px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-500 focus:outline-none focus:ring-2 ring-red-300 transition-all'
+							onClick={() => {
+								onParsePastedHtml(appDetails.id);
+							}}
+						>
+							Extract app details
+						</button>
+						<p className='text-red-600 text-sm mt-4 mb-2'>
+							Alternatively, with <a href='https://jqlang.org/' target='_blank' rel='noopener noreferrer' className='underline'>jq</a> installed you can get the details as JSON directly:
+						</p>
+						<pre className='bg-red-100 text-red-900 text-xs p-3 rounded overflow-x-auto whitespace-pre-wrap break-all'><code>{curlJqCommand(appDetails.id)}</code></pre>
 					</div>
 					<p className='mt-4'><button type='button' onClick={() => {
 						setAppDetails({type: 'ready', id: appDetails.id});

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,25 @@
+# Proxy worker
+
+A tiny Cloudflare Worker the web app uses to fetch Google's OAuth error page.
+
+Public CORS proxies can't do this job: browsers force-attach `Sec-Fetch-Site: cross-site` to cross-site fetches (JavaScript cannot remove it), pass-through proxies forward it to Google, and Google responds 403. This worker instead makes its own clean request with a browser-like `User-Agent`, so it works regardless of what the browser sends. It only proxies `https://accounts.google.com/signin/oauth/error*` URLs.
+
+## Deploy
+
+```sh
+cd worker
+npx wrangler login   # one-time browser OAuth
+npx wrangler deploy
+```
+
+Then put the printed URL (e.g. `https://google-client-id-lookup-proxy.<account>.workers.dev`) at the front of `corsProxies` in `src/pages/index.tsx`:
+
+```ts
+(url: string) => `https://google-client-id-lookup-proxy.<account>.workers.dev/?url=${encodeURIComponent(url)}`,
+```
+
+The free tier (100k requests/day) is far more than this tool needs.
+
+## Caveat
+
+Google may serve different content to Cloudflare datacenter IPs than to residential IPs — verify a lookup end-to-end after deploying.

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,39 @@
+// Cloudflare Worker that fetches Google's OAuth error page with clean,
+// browser-like headers and returns it with CORS headers.
+//
+// This exists because the lookup can't be done from the browser directly:
+// - Google only serves the page with app details to browser-like User-Agents
+// - Google rejects (403) requests carrying Sec-Fetch-Site: cross-site, which
+//   browsers force-attach to cross-site fetches and JavaScript cannot remove,
+//   so public pass-through CORS proxies that forward request headers all fail
+//
+// Deploy with: npx wrangler deploy (see worker/README.md)
+
+const ALLOWED_PREFIX = 'https://accounts.google.com/signin/oauth/error';
+
+export default {
+	async fetch(request) {
+		const url = new URL(request.url).searchParams.get('url');
+		if (!url || !url.startsWith(ALLOWED_PREFIX)) {
+			return new Response(`Bad request: url param must start with ${ALLOWED_PREFIX}`, {status: 400});
+		}
+
+		const upstream = await fetch(url, {
+			redirect: 'follow',
+			headers: {
+				'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+				Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+				'Accept-Language': 'en',
+			},
+		});
+
+		return new Response(upstream.body, {
+			status: upstream.status,
+			headers: {
+				'Content-Type': upstream.headers.get('content-type') ?? 'text/html',
+				'Access-Control-Allow-Origin': '*',
+				'Cache-Control': 'public, max-age=3600',
+			},
+		});
+	},
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,6 @@
+name = "google-client-id-lookup-proxy"
+main = "index.js"
+compatibility_date = "2026-07-01"
+
+[observability]
+enabled = true


### PR DESCRIPTION
Follow-up to #27. Testing on the deployed site showed **no public CORS proxy can work from a real browser**: browsers force-attach `Sec-Fetch-Site: cross-site` to cross-site fetches (JavaScript cannot remove it — it's a forbidden header), pass-through proxies forward it to Google, and Google returns 403. Verified in curl: identical request minus that header succeeds; with it, Google serves its 403 page. All tested proxies (corsmirror, proxy.cors.sh, corsproxy.io, allorigins, codetabs) fail this way.

This PR makes the site useful despite that:

- **Upfront banner** saying in-browser lookup is unreliable and pointing at the manual path.
- **Paste-back fallback**: the error state shows a plain `curl` command (prefilled with the entered client ID); pasting its output into a textarea runs it through the same parser and renders the normal results view. No grep/sed/jq needed. Verified against Google's real page output (and a bad paste is detected cleanly).
- **curl+jq one-liner** kept for terminal-only users.
- **`worker/`**: a ~35-line Cloudflare Worker that proxies the lookup with its own clean browser-like headers, restricted to `accounts.google.com/signin/oauth/error*`. Deploying it (`npx wrangler login && npx wrangler deploy`) and adding its URL to `corsProxies` makes in-browser lookup reliable again — see worker/README.md.
- README status section rewritten to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)